### PR TITLE
Fix broken link to Buffalo project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Sendgrid Buffalo Sender
 
-This is a [buffalo](github.com/gobuffalo/buffalo) sender for the [Sendgrid](https://sendgrid.com) email service.
+This is a [buffalo](https://github.com/gobuffalo/buffalo) sender for the [Sendgrid](https://sendgrid.com) email service.
 
 #### How to use
 


### PR DESCRIPTION
When used without protocol prefix, GitHub assumes, that href target is located inside current project.
It ends up incorrectly targeted at https://github.com/paganotoni/sendgrid-sender/blob/master/github.com/gobuffalo/buffalo